### PR TITLE
Add setJobDescriptionFromMetadata() step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is a list of all steps implemented in the library. Click on a particular st
 * [isPullRequest()](./docs/steps/isPullRequest.md)
 * [sendMessage()](./docs/steps/sendMessage.md)
 * [setBuildNameFromArtifactId()](./docs/steps/setBuildNameFromArtifactId.md)
+* [setJobDescriptionFromMetadata()](./docs/steps/setJobDescriptionFromMetadata.md)
 
 ## Limitations
 

--- a/docs/steps/setJobDescriptionFromMetadata.md
+++ b/docs/steps/setJobDescriptionFromMetadata.md
@@ -1,0 +1,26 @@
+# setJobDescriptionFromMetadata() step
+
+This step sets the description of a job in Jenkins.
+
+## Parameters
+
+* **pipelineMetadata**: map; pipeline metadata
+
+## Example Usage
+
+```groovy
+def pipelineMetadata = [
+    pipelineName: 'rpmdeplint',
+    pipelineDescription: 'Finding errors in RPM packages in the context of their dependency graph',
+    testCategory: 'functional',
+    testType: 'rpmdeplint',
+    maintainer: 'Fedora CI',
+    docs: 'https://github.com/fedora-ci/rpmdeplint-pipeline',
+    contact: [
+        irc: '#fedora-ci',
+        email: 'ci@lists.fedoraproject.org'
+    ],
+]
+
+setJobDescriptionFromMetadata(pipelineMetadata: pipelineMetadata)
+```

--- a/vars/setJobDescriptionFromMetadata.groovy
+++ b/vars/setJobDescriptionFromMetadata.groovy
@@ -1,0 +1,40 @@
+#!/usr/bin/groovy
+
+/**
+ * setJobDescriptionFromMetadata() step.
+ */
+def call(Map params = [:]) {
+    def pipelineMetadata = params.get('pipelineMetadata')
+
+    def jobDescription
+    def job = Jenkins.instance.getItemByFullName(env.JOB_NAME)
+
+    def description = pipelineMetadata.get('pipelineDescription')
+    def maintainer = pipelineMetadata.get('maintainer')
+    def docs = pipelineMetadata.get('docs')
+
+    def contact = ''
+    // translate 'contact' map into a human readable string, e.g.:
+    // [irc: '#fedora-ci', email: 'ci@lists.fedoraproject.org']
+    // translates into "via irc on #fedora-ci or via email on ci@lists.fedoraproject.org"
+    pipelineMetadata.get('contact').each { key, value ->
+        if (contact) {
+            contact += " or "
+        }
+        contact += "via ${key} on ${value}"
+    }
+
+    jobDescription = """
+<p>
+${description}
+</p>
+<p>
+This pipeline is maintained by ${maintainer}. Feel free to reach out to us ${contact}.
+</p>
+<p>
+You can find more information about this pipeline in the <a href="${docs}">official documentation</a>.
+</p>
+"""
+
+    job.setDescription(jobDescription)
+}


### PR DESCRIPTION
This step takes `pipelineMetadata` and produces pipeline job description in following format:

```
Finding errors in RPM packages in the context of their dependency graph

This pipeline is maintained by Fedora CI. Feel free to reach out to us via irc on #fedora-ci or via email on ci@lists.fedoraproject.org.

You can find out more about this pipeline in the official documentation.
```