### PR TITLE
Do not fail the pipeline if setBuildNameFromArtifactId step fails

### DIFF
--- a/test/groovy/SetBuildNameFromArtifactIdTest.groovy
+++ b/test/groovy/SetBuildNameFromArtifactIdTest.groovy
@@ -1,0 +1,36 @@
+import org.junit.*
+import com.lesfurets.jenkins.unit.*
+import static groovy.test.GroovyAssert.*
+
+
+class SetBuildNameFromArtifactIdTest extends BasePipelineTest {
+
+    @Before
+    void init() {
+        super.setUp()
+    }  
+
+    def setBuildNameFromArtifactId(params) {
+        super.setUp()
+        def step = helper.loadScript('vars/setBuildNameFromArtifactId.groovy', binding)
+        return step(params)
+    }
+
+    @Test
+    void testSetBuildNameFromArtifactId() {
+        def result = setBuildNameFromArtifactId(artifactId: 'koji-build:46436038')
+        assertEquals '[koji-build] wget-1.20.3-6.fc33', binding.getVariable('currentBuild').displayName.toString()
+    }
+
+    @Test
+    void testSetBuildNameFromArtifactIdBadArtifactType() {
+        def result = setBuildNameFromArtifactId(artifactId: 'unknown-build:46436038')
+        assertEquals "UNKNOWN ARTIFACT TYPE: 'unknown-build'", binding.getVariable('currentBuild').displayName.toString()
+    }
+
+    @Test
+    void testSetBuildNameFromArtifactIdError() {
+        def result = setBuildNameFromArtifactId(artifactId: 'koji-build:99999999')
+        assertEquals "INVALID ARTIFACT ID: 'koji-build:99999999'", binding.getVariable('currentBuild').displayName.toString()
+    }
+}

--- a/vars/setBuildNameFromArtifactId.groovy
+++ b/vars/setBuildNameFromArtifactId.groovy
@@ -7,19 +7,25 @@ import org.fedoraproject.jenkins.koji.Koji
  */
 def call(Map params = [:]) {
     def artifactId = params.get('artifactId')
-
-    def artifactType = artifactId.split(':')[0]
-    def taskId = artifactId.split(':')[1]
-
     def displayName
 
-    if (artifactType == 'koji-build') {
-        def koji = new Koji()
-        def taskInfo = koji.getTaskInfo(taskId.toInteger())
-        displayName = "[${artifactType}] ${taskInfo.nvr}"
-        if (taskInfo.scratch) {
-            displayName = "[scratch] ${displayName}"
+    try {
+        def artifactType = artifactId.split(':')[0]
+        def taskId = artifactId.split(':')[1]
+
+        if (artifactType == 'koji-build') {
+            def koji = new Koji()
+            def taskInfo = koji.getTaskInfo(taskId.toInteger())
+            displayName = "[${artifactType}] ${taskInfo.nvr}"
+            if (taskInfo.scratch) {
+                displayName = "[scratch] ${displayName}"
+            }
+        } else {
+            displayName = "UNKNOWN ARTIFACT TYPE: '${artifactType}'"
         }
+    } catch (Exception ex) {
+        error("${ex}")
+        displayName = "INVALID ARTIFACT ID: '${artifactId}'"
     }
 
     currentBuild.displayName = displayName


### PR DESCRIPTION
Pipeline will not fail in `setBuildNameFromArtifactId()` step if the provided `artifactId` is invalid.