### PR TITLE
Generate pipeline id from artifactId + testcase name

### DIFF
--- a/src/org/fedoraproject/jenkins/Utils.groovy
+++ b/src/org/fedoraproject/jenkins/Utils.groovy
@@ -42,6 +42,18 @@ class Utils {
     }
 
     /*
+     * Returns a pipeline ID for the artifactId and testcase name.
+     *
+     * Working with the same artifactId and the same testcase name
+     * will produce the same pipeline ID.
+     *
+     * @return pipeline ID
+     */
+    static String generatePipelineIdFromArtifactIdAndTestcase(def artifactId, def testcase) {
+        return string2sha256(artifactId + testcase)
+    }
+
+    /*
      * Returns current UTC timestamp.
      *
      * @return current UTC timestamp

--- a/src/org/fedoraproject/jenkins/messages/FedoraUpdateMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/FedoraUpdateMessageBuilder.groovy
@@ -53,11 +53,6 @@ def buildMessageQueued(String artifactId, Map pipelineMetadata) {
     }
     msgTemplate['artifact']['builds'] = builds
 
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
-
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']
     msgTemplate['test']['category'] = pipelineMetadata['testCategory']
@@ -121,11 +116,6 @@ def buildMessageComplete(String artifactId, Map pipelineMetadata, String xunit) 
         builds.add([nvr: nvr])
     }
     msgTemplate['artifact']['builds'] = builds
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     def result = 'needs_inspection'
@@ -202,11 +192,6 @@ def buildMessageError(String artifactId, Map pipelineMetadata, String xunit) {
         builds.add([nvr: nvr])
     }
     msgTemplate['artifact']['builds'] = builds
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']

--- a/src/org/fedoraproject/jenkins/messages/MessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/MessageBuilder.groovy
@@ -14,6 +14,21 @@ def getMessageVersion() {
     return '0.2.1'
 }
 
+def getPipelineSection(artifactType, taskId, pipelineMetadata) {
+    // construct the pipeline section
+    def namespace = "${pipelineMetadata['maintainer'].toLowerCase().replace(' ', '-')}.${artifactType}"
+    def pipeline = [
+        'id': Utils.generatePipelineIdFromArtifactIdAndTestcase(
+            "${artifactType}:${taskId}",
+            "${namespace}.${pipelineMetadata['testType']}.${pipelineMetadata['testCategory']}"
+        ),
+        'name': pipelineMetadata['pipelineName'],
+        'build': "${env.BUILD_NUMBER}"
+    ]
+    return pipeline
+}
+
+
 def buildMessageQueued(String artifactId, String artifactType, String taskId, Map pipelineMetadata) {
 
     def msg
@@ -30,8 +45,13 @@ def buildMessageQueued(String artifactId, String artifactType, String taskId, Ma
         throw new Exception("Unknown artifact type: ${artifactType}")
     }
 
-    if (msg && !msg.get('version')) {
-        msg['version'] = getMessageVersion()
+    if (msg) {
+        if (!msg.get('version')) {
+            msg['version'] = getMessageVersion()
+        }
+        if (!msg.get('pipeline')?.get('id') && !msg.get('thread_id')) {
+            msg['pipeline'] = getPipelineSection(artifactType, taskId, pipelineMetadata)
+        }
     }
     return msg
 }
@@ -53,8 +73,13 @@ def buildMessageRunning(String artifactId, String artifactType, String taskId, M
         throw new Exception("Unknown artifact type: ${artifactType}")
     }
 
-    if (msg && !msg.get('version')) {
-        msg['version'] = getMessageVersion()
+    if (msg) {
+        if (!msg.get('version')) {
+            msg['version'] = getMessageVersion()
+        }
+        if (!msg.get('pipeline')?.get('id') && !msg.get('thread_id')) {
+            msg['pipeline'] = getPipelineSection(artifactType, taskId, pipelineMetadata)
+        }
     }
     return msg
 }
@@ -76,8 +101,13 @@ def buildMessageComplete(String artifactId, String artifactType, String taskId, 
         throw new Exception("Unknown artifact type: ${artifactType}")
     }
 
-    if (msg && !msg.get('version')) {
-        msg['version'] = getMessageVersion()
+    if (msg) {
+        if (!msg.get('version')) {
+            msg['version'] = getMessageVersion()
+        }
+        if (!msg.get('pipeline')?.get('id') && !msg.get('thread_id')) {
+            msg['pipeline'] = getPipelineSection(artifactType, taskId, pipelineMetadata)
+        }
     }
     return msg
 }
@@ -99,8 +129,13 @@ def buildMessageError(String artifactId, String artifactType, String taskId, Map
         throw new Exception("Unknown artifact type: ${artifactType}")
     }
 
-    if (msg && !msg.get('version')) {
-        msg['version'] = getMessageVersion()
+    if (msg) {
+        if (!msg.get('version')) {
+            msg['version'] = getMessageVersion()
+        }
+        if (!msg.get('pipeline')?.get('id') && !msg.get('thread_id')) {
+            msg['pipeline'] = getPipelineSection(artifactType, taskId, pipelineMetadata)
+        }
     }
     return msg
 }

--- a/src/org/fedoraproject/jenkins/messages/PullRequestMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/PullRequestMessageBuilder.groovy
@@ -41,11 +41,6 @@ def buildMessageQueued(String artifactType, String taskId, Map pipelineMetadata)
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
 
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
-
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']
     msgTemplate['test']['category'] = pipelineMetadata['testCategory']
@@ -92,11 +87,6 @@ def buildMessageRunning(String artifactType, String taskId, Map pipelineMetadata
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
 
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
-
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']
     msgTemplate['test']['category'] = pipelineMetadata['testCategory']
@@ -136,11 +126,6 @@ def buildMessageComplete(String artifactType, String taskId, Map pipelineMetadat
     msgTemplate['artifact']['commit_hash'] = uidCommitAndComment.get('commitId')
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     def result = 'needs_inspection'
@@ -213,11 +198,6 @@ def buildMessageError(String artifactType, String taskId, Map pipelineMetadata, 
     msgTemplate['artifact']['commit_hash'] = uidCommitAndComment.get('commitId')
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']

--- a/src/org/fedoraproject/jenkins/messages/RHPullRequestMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/RHPullRequestMessageBuilder.groovy
@@ -42,13 +42,16 @@ def buildMessageRunning(String artifactType, String taskId, Map pipelineMetadata
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
 
-    // pipeline section
-    msgTemplate['thread_id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-
     // test section
     msgTemplate['namespace'] = "${pipelineMetadata['maintainer'].toLowerCase().replace(' ', '-')}.dist-git-pr"
     msgTemplate['category'] = pipelineMetadata['testCategory']
     msgTemplate['type'] = pipelineMetadata['testType']
+
+    // pipeline section
+    msgTemplate['thread_id'] = Utils.generatePipelineIdFromArtifactIdAndTestcase(
+        "${artifactType}:${taskId}",
+        "${msgTemplate['namespace']}.${artifactType}.${msgTemplate['type']}.${msgTemplate['category']}"
+    )
 
     // run section
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"
@@ -95,9 +98,6 @@ def buildMessageComplete(String artifactType, String taskId, Map pipelineMetadat
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
 
-    // pipeline section
-    msgTemplate['thread_id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-
     // test section
     def result = 'needs_inspection'
     if (currentBuild.result == 'SUCCESS') {
@@ -111,6 +111,12 @@ def buildMessageComplete(String artifactType, String taskId, Map pipelineMetadat
     msgTemplate['type'] = pipelineMetadata['testType']
     msgTemplate['status'] = result
     msgTemplate['xunit'] = xunit
+
+    // pipeline section
+    msgTemplate['thread_id'] = Utils.generatePipelineIdFromArtifactIdAndTestcase(
+        "${artifactType}:${taskId}",
+        "${msgTemplate['namespace']}.${artifactType}.${msgTemplate['type']}.${msgTemplate['category']}"
+    )
 
     // run section
     msgTemplate['run']['url'] = "${env.BUILD_URL}"
@@ -157,14 +163,17 @@ def buildMessageError(String artifactType, String taskId, Map pipelineMetadata, 
     msgTemplate['artifact']['issuer'] = pullRequestInfo.get('user', [:])?.get('name')
     msgTemplate['artifact']['uid'] = pullRequestInfo.get('uid')
 
-    // pipeline section
-    msgTemplate['thread_id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-
     msgTemplate['namespace'] = "${pipelineMetadata['maintainer'].toLowerCase().replace(' ', '-')}.dist-git-pr"
     msgTemplate['category'] = pipelineMetadata['testCategory']
     msgTemplate['type'] = pipelineMetadata['testType']
     msgTemplate['status'] = "failed"
     msgTemplate['xunit'] = xunit
+
+    // pipeline section
+    msgTemplate['thread_id'] = Utils.generatePipelineIdFromArtifactIdAndTestcase(
+        "${artifactType}:${taskId}",
+        "${msgTemplate['namespace']}.${artifactType}.${msgTemplate['type']}.${msgTemplate['category']}"
+    )
 
     // run section
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"

--- a/src/org/fedoraproject/jenkins/messages/RpmBuildMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/RpmBuildMessageBuilder.groovy
@@ -38,11 +38,6 @@ def buildMessageQueued(String artifactType, String taskId, Map pipelineMetadata)
     msgTemplate['artifact']['scratch'] = taskInfo.scratch
     msgTemplate['artifact']['type'] = artifactType
 
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
-
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']
     msgTemplate['test']['category'] = pipelineMetadata['testCategory']
@@ -86,11 +81,6 @@ def buildMessageRunning(String artifactType, String taskId, Map pipelineMetadata
     msgTemplate['artifact']['scratch'] = taskInfo.scratch
     msgTemplate['artifact']['type'] = artifactType
 
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
-
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']
     msgTemplate['test']['category'] = pipelineMetadata['testCategory']
@@ -129,11 +119,6 @@ def buildMessageComplete(String artifactType, String taskId, Map pipelineMetadat
     msgTemplate['artifact']['baseline'] = taskInfo.nvr
     msgTemplate['artifact']['source'] = taskInfo.source.raw
     msgTemplate['artifact']['type'] = artifactType
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     def result = 'needs_inspection'
@@ -203,11 +188,6 @@ def buildMessageError(String artifactType, String taskId, Map pipelineMetadata, 
     msgTemplate['artifact']['nvr'] = taskInfo.nvr
     msgTemplate['artifact']['scratch'] = taskInfo.scratch
     msgTemplate['artifact']['type'] = artifactType
-
-    // pipeline section
-    msgTemplate['pipeline']['id'] = Utils.generatePipelineIdFromJobNameAndParams(env, params)
-    msgTemplate['pipeline']['name'] = pipelineMetadata['pipelineName']
-    msgTemplate['pipeline']['build'] = "${env.BUILD_NUMBER}"
 
     // test section
     msgTemplate['test']['type'] = pipelineMetadata['testType']

--- a/test/groovy/org/fedoraproject/jenkins/UtilsTest.groovy
+++ b/test/groovy/org/fedoraproject/jenkins/UtilsTest.groovy
@@ -85,4 +85,10 @@ class UtilsTest extends BasePipelineTest {
     void string2sha256Test() {
         assertEquals 'f5497b5bef7e1dd5985b5641e54239821b88cb2150a44774d8f0f8bdd251983a', Utils.string2sha256('abc abc')
     }
+
+    @Test
+    void generatePipelineIdFromArtifactIdAndTestcaseTest() {
+        def result = Utils.generatePipelineIdFromArtifactIdAndTestcase('koji-build:123456', 'fedora-ci.koji-build.rpminspect.static-analysis')
+        assertEquals 'f17d6cc02a77a34db48fd6bf39f2fb2a86a823b4849058292abc5300eb9b0c5b', result
+    }
 }


### PR DESCRIPTION
Generating pipeline id from env+params can cause issues when 2 different
jobs are reporting on the same test run.