### PR TITLE
[isTimeoutAborted] Fix param name: s/timeUnit/unit/g

### DIFF
--- a/vars/isTimeoutAborted.groovy
+++ b/vars/isTimeoutAborted.groovy
@@ -11,7 +11,7 @@ def call(Map params = [:]) {
     // and compare it with the expected timeout. Meh...
 
     def timeout = params.get('timeout')
-    def timeUnit = params.get('timeUnit', 'SECONDS')
+    def timeUnit = params.get('unit', 'SECONDS')
 
     if (timeout == null) {
         error('Required argument missing: timeout')


### PR DESCRIPTION
Pipelines are already using "unit" param.