### PR TITLE
[repoHasTests] Read also ci.fmf, if it exists in the repository

### DIFF
--- a/vars/repoHasTests.groovy
+++ b/vars/repoHasTests.groovy
@@ -1,6 +1,5 @@
 #!/usr/bin/groovy
 
-
 /**
  * repoHasTests() step.
  */
@@ -36,13 +35,33 @@ def call(Map params = [:]) {
             }
             sh("git reset --hard ${ref}")
 
+            // TODO: This whole "CI config" section shouldn't be here.
+            // We need to find a better place how to work with repositories.
+            // And therefore, this "CI config" feature is not mentioned in documentation.
+            def ciConfig = [:]
+            def ciConfigPath = findFiles glob: 'ci.fmf'
+            echo "CI config in ${repoUrl} (${ref}): ${ciConfigPath}"
+            if (ciConfigPath) {
+                // FIXME: Groovy 2.x in Jenkins doesn't have a built-in support for YAML,
+                // and I don't want to add an external dependency.
+                // See also the comment above -- this whole section shouldn't be here
+                // and it will be moved elsewhere soon-ish.
+
+                // Convert ci.fmf (YAML) to ci.fmf.json (JSON)
+                sh(
+"""
+python3 -c "import yaml, json; y=yaml.safe_load(open('ci.fmf')); json.dump(y, open('ci.fmf.json', 'w'))"
+""")
+                ciConfig = readJSON(file: 'ci.fmf.json')
+            }
+
             // check STI first
             def stdStiFiles = findFiles glob: 'tests/tests*.yml'
             def nonStdStiFiles = findFiles glob: 'tests*.yml'
 
             echo "STI tests in ${repoUrl} (${ref}): ${stdStiFiles} ${nonStdStiFiles}"
             if (stdStiFiles || nonStdStiFiles) {
-                return [type: 'sti', files: (stdStiFiles + nonStdStiFiles).collect{ it.path } ]
+                return [type: 'sti', files: (stdStiFiles + nonStdStiFiles).collect{ it.path }, ciConfig: ciConfig]
             }
 
             // if STI tests were not found, let's try FMF
@@ -50,7 +69,7 @@ def call(Map params = [:]) {
             echo "FMF tests in ${repoUrl} (${ref}): ${stdFmf}"
 
             if (stdFmf) {
-                return [type: 'fmf', files: stdFmf.collect{ it.path }]
+                return [type: 'fmf', files: stdFmf.collect{ it.path }, ciConfig: ciConfig]
             }
 
             return [:]


### PR DESCRIPTION
This is a very hackish temporary solution. We need a better way how to
work with repositories in the pipeline library.

Groovy 2.x also doesn't have built-in support for YAML, so we just call
Python for now.