### PR TITLE
[sendMessage] Ignore dashboard - never set run.url to dashboard URL

### DIFF
--- a/src/org/fedoraproject/jenkins/messages/ModuleMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/ModuleMessageBuilder.groovy
@@ -194,9 +194,6 @@ def buildMessageComplete(
     if (msgTemplate['test']['xunit']) {
         msgTemplate['run']['url'] = "${env.BUILD_URL}testReport/(root)/tests/"
     }
-    if (env.FEDORA_CI_DASHBOARD_URL) {
-        msgTemplate['run']['url'] = "${env.FEDORA_CI_DASHBOARD_URL}/#/artifact/${artifactType}/aid/${taskId}?focus=tc:${msgTemplate['test']['namespace']}.${msgTemplate['test']['type']}.${msgTemplate['test']['category']}"
-    }
 
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"
     msgTemplate['run']['log_raw'] = "${env.BUILD_URL}consoleText"
@@ -265,9 +262,6 @@ def buildMessageError(
 
     // run section
     msgTemplate['run']['url'] = "${env.BUILD_URL}"
-    if (env.FEDORA_CI_DASHBOARD_URL) {
-        msgTemplate['run']['url'] = "${env.FEDORA_CI_DASHBOARD_URL}/#/artifact/${artifactType}/aid/${taskId}?focus=tc:${msgTemplate['test']['namespace']}.${msgTemplate['test']['type']}.${msgTemplate['test']['category']}"
-    }
 
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"
     msgTemplate['run']['log_raw'] = "${env.BUILD_URL}consoleText"

--- a/src/org/fedoraproject/jenkins/messages/RpmBuildMessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/RpmBuildMessageBuilder.groovy
@@ -198,9 +198,6 @@ def buildMessageComplete(
     if (msgTemplate['test']['xunit']) {
         msgTemplate['run']['url'] = "${env.BUILD_URL}testReport/(root)/tests/"
     }
-    if (env.FEDORA_CI_DASHBOARD_URL) {
-        msgTemplate['run']['url'] = "${env.FEDORA_CI_DASHBOARD_URL}/#/artifact/${artifactType}/aid/${taskId}?focus=tc:${msgTemplate['test']['namespace']}.${msgTemplate['test']['type']}.${msgTemplate['test']['category']}"
-    }
 
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"
     msgTemplate['run']['log_raw'] = "${env.BUILD_URL}consoleText"
@@ -269,9 +266,6 @@ def buildMessageError(
 
     // run section
     msgTemplate['run']['url'] = "${env.BUILD_URL}"
-    if (env.FEDORA_CI_DASHBOARD_URL) {
-        msgTemplate['run']['url'] = "${env.FEDORA_CI_DASHBOARD_URL}/#/artifact/${artifactType}/aid/${taskId}?focus=tc:${msgTemplate['test']['namespace']}.${msgTemplate['test']['type']}.${msgTemplate['test']['category']}"
-    }
 
     msgTemplate['run']['log'] = "${env.BUILD_URL}console"
     msgTemplate['run']['log_raw'] = "${env.BUILD_URL}consoleText"


### PR DESCRIPTION
There is no need for this. Dashboard doesn't support PRs
and scratch builds can point to TF results.