### PR TITLE
[sendMessage] Add runLog param

### DIFF
--- a/docs/steps/sendMessage.md
+++ b/docs/steps/sendMessage.md
@@ -18,6 +18,7 @@ This step requires the [JMS Messaging plugin](https://wiki.jenkins.io/display/JE
 * **messageProvider**: string; (optional) name of the topic the message provider to use
 * **xunit**: string; (optional) xunit with results
 * **runUrl**: string; (optional) URL that will appear in the message instead of the URL of the Jenkins build
+* **runLog**: string; (optional) Log URL that will appear in the message instead of the URL of the Jenkins console
 * **isSkipped**: boolean; [**DEPRECATED**: please use "isInfo" instead] (optional) indicator whether this test was skipped or not; a "note" param can be used to provide an explanation on why the test was skipped
 * **isInfo**: boolean; (optional) indicator whether this result is just informational or not; note: this field is only applicable for "complete" messages
 * **note**: string; (optional) arbitrary note about the test result

--- a/src/org/fedoraproject/jenkins/messages/MessageBuilder.groovy
+++ b/src/org/fedoraproject/jenkins/messages/MessageBuilder.groovy
@@ -35,6 +35,7 @@ def buildMessageQueued(
     String taskId,
     Map pipelineMetadata,
     String runUrl,
+    String runLog,
     String scenario,
     String testType,
     String testProfile
@@ -75,6 +76,9 @@ def buildMessageQueued(
         if (runUrl && msg.get('run', {})?.get('url')) {
             msg['run']['url'] = runUrl
         }
+        if (runLog && msg.get('run', {})?.get('log')) {
+            msg['run']['log'] = runLog
+        }
     }
     return msg
 }
@@ -86,6 +90,7 @@ def buildMessageRunning(
     String taskId,
     Map pipelineMetadata,
     String runUrl,
+    String runLog,
     String scenario,
     String testType,
     String testProfile
@@ -126,6 +131,9 @@ def buildMessageRunning(
         if (runUrl && msg.get('run', {})?.get('url')) {
             msg['run']['url'] = runUrl
         }
+        if (runLog && msg.get('run', {})?.get('log')) {
+            msg['run']['log'] = runLog
+        }
     }
     return msg
 }
@@ -138,6 +146,7 @@ def buildMessageComplete(
     Map pipelineMetadata,
     String xunit,
     String runUrl,
+    String runLog,
     Boolean isSkipped,
     String note,
     String scenario,
@@ -181,6 +190,9 @@ def buildMessageComplete(
         if (runUrl && msg.get('run', {})?.get('url')) {
             msg['run']['url'] = runUrl
         }
+        if (runLog && msg.get('run', {})?.get('log')) {
+            msg['run']['log'] = runLog
+        }
         if (testResult && !isSkipped) {
             if (msg.get('test')) {
                 msg['test']['result'] = testResult
@@ -200,6 +212,7 @@ def buildMessageError(
     Map pipelineMetadata,
     String xunit,
     String runUrl,
+    String runLog,
     String scenario,
     String errorReason,
     String testType,
@@ -240,6 +253,9 @@ def buildMessageError(
         }
         if (runUrl && msg.get('run', {})?.get('url')) {
             msg['run']['url'] = runUrl
+        }
+        if (runLog && msg.get('run', {})?.get('log')) {
+            msg['run']['log'] = runLog
         }
     }
     return msg

--- a/vars/sendMessage.groovy
+++ b/vars/sendMessage.groovy
@@ -19,6 +19,7 @@ def call(Map params = [:]) {
     def messageProvider = params.get('messageProvider') ?: env.FEDORA_CI_MESSAGE_PROVIDER
     def xunit = params.get('xunit') ?: ''
     def runUrl = params.get('runUrl') ?: ''
+    def runLog = params.get('runLog') ?: ''
     def isSkipped = params.get('isSkipped', false)?.toBoolean()
     def isInfo = params.get('isInfo', false)?.toBoolean()
     def note = params.get('note') ?: ''
@@ -98,6 +99,7 @@ def call(Map params = [:]) {
                 taskId,
                 pipelineMetadata,
                 runUrl,
+                runLog,
                 scenario,
                 testType,
                 testProfile
@@ -111,6 +113,7 @@ def call(Map params = [:]) {
                 taskId,
                 pipelineMetadata,
                 runUrl,
+                runLog,
                 scenario,
                 testType,
                 testProfile
@@ -125,6 +128,7 @@ def call(Map params = [:]) {
                 pipelineMetadata,
                 xunit,
                 runUrl,
+                runLog,
                 isSkipped,
                 note,
                 scenario,
@@ -142,6 +146,7 @@ def call(Map params = [:]) {
                 pipelineMetadata,
                 xunit,
                 runUrl,
+                runLog,
                 scenario,
                 errorReason,
                 testType,


### PR DESCRIPTION
The default run.log URL (Jenkins console) can overridden by this param.