### PR TITLE
[repoHasTests] Add option to clone the repo with credentials

### DIFF
--- a/docs/steps/repoHasTests.md
+++ b/docs/steps/repoHasTests.md
@@ -1,11 +1,15 @@
 # repoHasTests() step
 
-This step clones the given repository and checks if there are any supported (STI/TMT) tests inside.
+This step clones the given repository and checks if there are any supported (STI/tmt) tests inside.
+
+If the `useCloneCredentials` option is used, then the credentials stored in the `GIT_CLONE_AUTH_STRING`
+environment variable will be used to clone the repository.
 
 ## Parameters
 
 * **repoUrl**: string; repository URL
 * **ref**: string; git reference
+* **useCloneCredentials**: boolean; (optional) use clone credentials (default: false)
 
 ## Example Usage
 

--- a/vars/repoHasTests.groovy
+++ b/vars/repoHasTests.groovy
@@ -8,6 +8,11 @@ def call(Map params = [:]) {
     def repoUrl = params.get('repoUrl')
     def ref = params.get('ref')
     def context = params.get('context')
+    def useCloneCredentials = params.get('useCloneCredentials', false)
+
+    if (useCloneCredentials && env.GIT_CLONE_AUTH_STRING) {
+        repoUrl = repoUrl.replace('://', "://${env.GIT_CLONE_AUTH_STRING}@")
+    }
 
     dir("temp-repoHasTests${env.BUILD_ID}") {
         try {


### PR DESCRIPTION
This is needed for private repositories that need authentication.

Signed-off-by: Michal Srb <michal@redhat.com>