### PR TITLE
[repoHasTests] Add option to fetch also merge requests

### DIFF
--- a/docs/steps/repoHasTests.md
+++ b/docs/steps/repoHasTests.md
@@ -10,6 +10,7 @@ environment variable will be used to clone the repository.
 * **repoUrl**: string; repository URL
 * **ref**: string; git reference
 * **useCloneCredentials**: boolean; (optional) use clone credentials (default: false)
+* **fetchMergeRequests**: boolean; (optional) fetch also merge requests (default: false)
 
 ## Example Usage
 

--- a/vars/repoHasTests.groovy
+++ b/vars/repoHasTests.groovy
@@ -9,6 +9,7 @@ def call(Map params = [:]) {
     def ref = params.get('ref')
     def context = params.get('context')
     def useCloneCredentials = params.get('useCloneCredentials', false)
+    def fetchMergeRequests = params.get('fetchMergeRequests', false)
 
     if (useCloneCredentials && env.GIT_CLONE_AUTH_STRING) {
         repoUrl = repoUrl.replace('://', "://${env.GIT_CLONE_AUTH_STRING}@")
@@ -26,6 +27,10 @@ def call(Map params = [:]) {
                 }
                 retryCounter += 1
                 sh("git clone ${repoUrl} .")
+
+                if (fetchMergeRequests) {
+                    sh("git fetch origin +refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*")
+                }
             }
             // check that the commit hash exists
             def refExists = sh(script: "git cat-file -e ${ref}", returnStatus: true)


### PR DESCRIPTION
If we clone target git repository, we won't see merge request
branches by default. This new option tells git to fetch those extra
branches as well.

Note this will likely only work with GitLab. But that is what
we need right now.

Signed-off-by: Michal Srb <michal@redhat.com>