### PR TITLE
Increase readFileFromArtifactStorage default timeout to 15 minutes

### DIFF
--- a/docs/steps/readFileFromArtifactStorage.md
+++ b/docs/steps/readFileFromArtifactStorage.md
@@ -5,7 +5,7 @@ This step tries to read the file from the given URL. The URL should point to the
 ## Parameters
 
 * **url**: string; File URL
-* **timeoutSeconds**: int (optional); Timeout in seconds (default: 120)
+* **timeoutSeconds**: int (optional); Timeout in seconds (default: 900)
 
 ## Example Usage
 

--- a/vars/readFileFromArtifactStorage.groovy
+++ b/vars/readFileFromArtifactStorage.groovy
@@ -5,7 +5,7 @@
  */
 def call(Map params = [:]) {
     def url = params.get('url')
-    def timeoutSeconds = params.get('timeoutSeconds', 120)?.toInteger()
+    def timeoutSeconds = params.get('timeoutSeconds', 900)?.toInteger()
 
     def response
     if (url) {


### PR DESCRIPTION
It seems sometimes it takes more than 2 minutes to get the test results from TFT to our artifacts storage. As first thing, let's try to increase the timeout to 15 minutes.